### PR TITLE
Replaced deprecated function call

### DIFF
--- a/lua/eagle/init.lua
+++ b/lua/eagle/init.lua
@@ -231,7 +231,7 @@ function M.check_lsp_support()
   local filetype = vim.bo.filetype
 
   -- get all active clients
-  local clients = vim.lsp.get_active_clients()
+  local clients = vim.lsp.get_clients()
 
   -- filter the clients based on the filetype of the current buffer
   local relevant_clients = {}


### PR DESCRIPTION
`vim.lsp.get_active_clients()` --> `vim.lsp.get_clients()`, as the former "will be removed in Nvim 0.12"