### PR TITLE
fix: Replace client.supports_method with client:supports_method

### DIFF
--- a/lua/eagle/util.lua
+++ b/lua/eagle/util.lua
@@ -190,7 +190,7 @@ function M.debug_lsp_clients(opts)
         }
 
         for _, method in ipairs(common_methods) do
-            add("• " .. method .. ": " .. tostring(client.supports_method(method)))
+            add("• " .. method .. ": " .. tostring(client:supports_method(method)))
         end
 
         -- Server capabilities (detailed info)
@@ -346,7 +346,7 @@ local function check_lsp_support()
 
     -- check if any of the relevant clients support textDocument/hover
     for _, client in ipairs(relevant_clients) do
-        if client.supports_method("textDocument/hover") then
+        if client:supports_method("textDocument/hover") then
             if config.options.logging then
                 print("Found LSP client supporting textDocument/hover: " .. client.name)
             end


### PR DESCRIPTION
Meant to fix this warning in Nvim nightly:

```vimdoc
==============================================================================
vim.deprecated:                                                           1 ⚠️

 ~
- ⚠️ WARNING client.supports_method is deprecated. Feature will be removed in Nvim 0.13
  - ADVICE:
    - use client:supports_method instead.
    - stack traceback:
        /home/distrorockhopper/.local/share/nvim/site/pack/core/opt/eagle.nvim/lua/eagle/util.lua:349
        /home/distrorockhopper/.local/share/nvim/site/pack/core/opt/eagle.nvim/lua/eagle/util.lua:366
        /home/distrorockhopper/.local/share/nvim/site/pack/core/opt/eagle.nvim/lua/eagle/mouse_handler.lua:72
        vim/_editor.lua:0
```