### PR TITLE
Guard against stale `eagle_buf` in `create_eagle_win`

### DIFF
--- a/lua/eagle/util.lua
+++ b/lua/eagle/util.lua
@@ -901,7 +901,7 @@ function M.create_eagle_win(keyboard_event)
     end
 
     -- create a buffer with buflisted = false and scratch = true
-    if eagle_buf then
+    if eagle_buf and vim.api.nvim_buf_is_valid(eagle_buf) then
         vim.api.nvim_buf_delete(eagle_buf, {})
     end
     eagle_buf = vim.api.nvim_create_buf(false, true)


### PR DESCRIPTION
`eagle_buf` is a module-local variable tracking eagle's scratch buffer across hover invocations. If something external deletes that buffer (e.g. a session manager plugin restoring a new session), the next call to `create_eagle_win` throws `Invalid buffer id` when trying to delete it, because Neovim's `nvim_buf_delete` doesn't tolerate stale ids.

This PR adds a validity check before deletion, matching the pattern used elsewhere in Neovim plugin code when dealing with ids that may outlive their referent.

Reproduced the crash by triggering hover, then switching sessions via `auto-session` (which wipes buffers), then triggering hover again. Confirmed the error occurs on `main` and is resolved with this patch — hover continues to work normally after a session switch instead of requiring a Neovim restart.

Tested with:
NVIM v0.12.4
soulis-1256/eagle.nvim commit: d503b168932160b07d4d09551d90d5fbb388b641
rmagatti/auto-session commit: 6cde3874a9283c2db55627acca5f28e4fa402320

